### PR TITLE
Changed up the way that we generate MD5. Did a bit of research and it…

### DIFF
--- a/RTP.Net/RTPHeader.cs
+++ b/RTP.Net/RTPHeader.cs
@@ -291,7 +291,7 @@ namespace RTP.Net
 
         }
 
-        public uint Length => 96 + 32 * (uint)this.CSRCList.Length;
+        public uint Length => 12 + 4 * (uint)this.CSRCList.Length;
 
         public byte[] Serialize()
         {

--- a/RTP.Net/RTPHeader.cs
+++ b/RTP.Net/RTPHeader.cs
@@ -291,14 +291,7 @@ namespace RTP.Net
 
         }
 
-
-        public uint Length
-        {
-            get
-            {
-                return 96 + 32 * (uint)this.CSRCList.Length;
-            }
-        }
+        public uint Length => 96 + 32 * (uint)this.CSRCList.Length;
 
         public byte[] Serialize()
         {
@@ -347,9 +340,14 @@ namespace RTP.Net
             ret[3] = BitConverter.GetBytes(sn)[1];
         }
 
-        private byte Convert2Byte(bool b)
+        /// <summary>
+        ///     Converts a boolean to a byte.
+        /// </summary>
+        /// <param name="b">The boolean we are passing as an argument</param>
+        /// <returns>The byte representation of a boolean.</returns>
+        private static byte Convert2Byte(bool byteBoolean)
         {
-            return b == true ? (byte)1 : (byte)0;
+            return byteBoolean ? (byte)1 : (byte)0;
         }
     }
 }

--- a/RTP.Net/Utils/IdentificationGeneration/RandomIdentificationGenerator.cs
+++ b/RTP.Net/Utils/IdentificationGeneration/RandomIdentificationGenerator.cs
@@ -2,8 +2,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading;
 
 namespace RTP.Net.Utils.IdentificationGeneration
 {
@@ -16,7 +14,12 @@ namespace RTP.Net.Utils.IdentificationGeneration
         /// <summary>
         ///     A pseudorandom number generator.
         /// </summary>
-        private static readonly Random Random = new Random();
+        private static readonly RNGCryptoServiceProvider Random = new RNGCryptoServiceProvider();
+
+        /// <summary>
+        ///     The number of bytes that we want to use.
+        /// </summary>
+        private const short ByteArraySize = 16;
 
         /// <summary>
         ///     Our method gets a random 32-bit identifier using
@@ -26,28 +29,15 @@ namespace RTP.Net.Utils.IdentificationGeneration
         /// </summary>
         public static byte[] GetRandomIdentification(SDESType type = SDESType.CNAME)
         {
-            // Basically obtains various sources of randomness 
-            var randomNumber = Random.Next(int.MaxValue);
-            var processId = Process.GetCurrentProcess().ToString();
-            var dateTime = DateTime.Now.ToString("h:mm:ss tt zz");
-            var typeCode = type.GetHashCode();
+            // an array of bytes
+            var randomByteArray = new byte[ByteArraySize];
 
-
-            // a binary writer just for Jackson Dorsett :)
-            using var memoryStream = new MemoryStream();
-            using var binaryWriter = new BinaryWriter(memoryStream);
-            binaryWriter.Write(randomNumber);
-            binaryWriter.Write(processId);
-            binaryWriter.Write(dateTime);
-            binaryWriter.Write(typeCode);
+            // fills the byte array with cryptographically random values
+            Random.GetBytes(randomByteArray);
 
             // use the C# library to do the heavy lifting
             using var md5 = MD5.Create();
-            var hash = md5.ComputeHash(memoryStream.ToArray(), 0, count: 4);
-
-            // closing the streams
-            memoryStream.Close();
-            binaryWriter.Close();
+            var hash = md5.ComputeHash(randomByteArray, 0, count: 4);
 
             // return our unique identifier :-)
             return hash;

--- a/RTP.Net/Utils/IdentificationGeneration/RandomIdentificationGenerator.cs
+++ b/RTP.Net/Utils/IdentificationGeneration/RandomIdentificationGenerator.cs
@@ -27,7 +27,7 @@ namespace RTP.Net.Utils.IdentificationGeneration
         ///     (https://tools.ietf.org/html/rfc1321)
         ///     https://msdn.microsoft.com/en-us/library/system.security.cryptography.md5%28v=vs.110%29.aspx
         /// </summary>
-        public static byte[] GetRandomIdentification(SDESType type = SDESType.CNAME)
+        public static byte[] GetRandomIdentification()
         {
             // an array of bytes
             var randomByteArray = new byte[ByteArraySize];


### PR DESCRIPTION
Sounds like Microsoft's native Cryptographic Random Number Generator API works efficiently for getting random data entropy. So, I went with that instead to have a higher success rate generating random numbers. Also, the method in question looks much nicer now!

```csharp
        /// <summary>
        ///     Our method gets a random 32-bit identifier using
        ///     MD5.
        ///     (https://tools.ietf.org/html/rfc1321)
        ///     https://msdn.microsoft.com/en-us/library/system.security.cryptography.md5%28v=vs.110%29.aspx
        /// </summary>
        public static byte[] GetRandomIdentification(SDESType type = SDESType.CNAME)
        {
            // an array of bytes
            var randomByteArray = new byte[ByteArraySize];

            // fills the byte array with cryptographically random values
            Random.GetBytes(randomByteArray);

            // use the C# library to do the heavy lifting
            using var md5 = MD5.Create();
            var hash = md5.ComputeHash(randomByteArray, 0, count: 4);

            // return our unique identifier :-)
            return hash;
        }
```